### PR TITLE
Add 'Show Chat When Typing' customizable toggle

### DIFF
--- a/src/components/completion/Input.tsx
+++ b/src/components/completion/Input.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components";
 import { MessageHistory } from "../history";
 import { UseCompletionReturn } from "@/types";
+import { useApp } from "@/contexts";
 import { CopyButton } from "../Markdown/copy-button";
 
 export const Input = ({
@@ -32,13 +33,14 @@ export const Input = ({
   inputRef,
   isHidden,
 }: UseCompletionReturn & { isHidden: boolean }) => {
+  const { customizable } = useApp();
   return (
     <div className="relative flex-1">
       <Popover
         open={isPopoverOpen}
         onOpenChange={(open) => {
-          if (!open && !isLoading) {
-            reset();
+          if (!open && !isLoading && !customizable.showChatWhenTyping.isEnabled) {
+            reset() ;
           }
         }}
       >
@@ -60,8 +62,8 @@ export const Input = ({
             />
 
             {/* Conversation thread indicator */}
-            {currentConversationId &&
-              conversationHistory.length > 0 &&
+            {((customizable.showChatWhenTyping.isEnabled && input.length > 0) ||
+              (currentConversationId && conversationHistory.length > 0)) &&
               !isLoading && (
                 <div className="absolute select-none right-1 top-1/2 -translate-y-1/2 flex items-center gap-1">
                   <MessageHistory

--- a/src/components/settings/ShowChatWhenTypingToggle.tsx
+++ b/src/components/settings/ShowChatWhenTypingToggle.tsx
@@ -1,0 +1,26 @@
+import { Switch, Label, Header } from "@/components";
+import { useApp } from "@/contexts";
+
+interface ShowChatWhenTypingToggleProps {
+  className?: string;
+}
+
+export const ShowChatWhenTypingToggle = ({
+  className,
+}: ShowChatWhenTypingToggleProps) => {
+  const { customizable, toggleShowChatWhenTyping } = useApp();
+
+  return (
+    <div className={className}>
+      <Header
+        title="Show Chat When Typing"
+        description="Display the chat history while you are typing."
+      />
+      <Switch
+        id="show-chat-when-typing-toggle"
+        checked={customizable.showChatWhenTyping.isEnabled}
+        onCheckedChange={toggleShowChatWhenTyping}
+      />
+    </div>
+  );
+};

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -13,6 +13,7 @@ import { ScreenshotConfigs } from "./ScreenshotConfigs";
 import { AppIconToggle } from "./AppIconToggle";
 import { AlwaysOnTopToggle } from "./AlwaysOnTopToggle";
 import { TitleToggle } from "./TitleToggle";
+import { ShowChatWhenTypingToggle } from "./ShowChatWhenTypingToggle";
 import { AIProviders } from "./ai-configs";
 import { STTProviders } from "./stt-configs";
 import { DeleteChats } from "./DeleteChats";
@@ -63,6 +64,9 @@ export const Settings = () => {
 
             {/* Title Toggle */}
             <TitleToggle />
+
+            {/* Show Chat When Typing Toggle */}
+            <ShowChatWhenTypingToggle />
 
             {/* Provider Selection */}
             <AIProviders {...settings} />

--- a/src/contexts/app.context.tsx
+++ b/src/contexts/app.context.tsx
@@ -10,6 +10,7 @@ import {
   updateAppIconVisibility,
   updateAlwaysOnTop,
   updateTitlesVisibility,
+  updateShowChatWhenTyping,
   CustomizableState,
 } from "@/lib/storage";
 import { IContextType, ScreenshotConfig, TYPE_PROVIDER } from "@/types";
@@ -100,11 +101,9 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     });
 
   // Unified Customizable State
-  const [customizable, setCustomizable] = useState<CustomizableState>({
-    appIcon: { isVisible: true },
-    alwaysOnTop: { isEnabled: true },
-    titles: { isEnabled: true },
-  });
+  const [customizable, setCustomizable] = useState<CustomizableState>(
+    getCustomizableState()
+  );
 
   // Pluely API State
   const [pluelyApiEnabled, setPluelyApiEnabledState] = useState<boolean>(
@@ -358,6 +357,12 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     loadData();
   };
 
+  const toggleShowChatWhenTyping = (isEnabled: boolean) => {
+    const newState = updateShowChatWhenTyping(isEnabled);
+    setCustomizable(newState);
+    loadData();
+  };
+
   const setPluelyApiEnabled = (enabled: boolean) => {
     setPluelyApiEnabledState(enabled);
     safeLocalStorage.setItem(STORAGE_KEYS.PLUELY_API_ENABLED, String(enabled));
@@ -382,6 +387,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     toggleAppIconVisibility,
     toggleAlwaysOnTop,
     toggleTitlesVisibility,
+    toggleShowChatWhenTyping,
     loadData,
     pluelyApiEnabled,
     setPluelyApiEnabled,

--- a/src/lib/storage/customizable.storage.ts
+++ b/src/lib/storage/customizable.storage.ts
@@ -10,12 +10,16 @@ export interface CustomizableState {
   titles: {
     isEnabled: boolean;
   };
+  showChatWhenTyping: {
+    isEnabled: boolean;
+  };
 }
 
 export const DEFAULT_CUSTOMIZABLE_STATE: CustomizableState = {
   appIcon: { isVisible: true },
   alwaysOnTop: { isEnabled: false },
   titles: { isEnabled: true },
+  showChatWhenTyping: { isEnabled: false },
 };
 
 /**
@@ -72,6 +76,18 @@ export const updateTitlesVisibility = (
 ): CustomizableState => {
   const currentState = getCustomizableState();
   const newState = { ...currentState, titles: { isEnabled } };
+  setCustomizableState(newState);
+  return newState;
+};
+
+/**
+ * Update show chat when typing state
+ * */
+export const updateShowChatWhenTyping = (
+  isEnabled: boolean
+): CustomizableState => {
+  const currentState = getCustomizableState();
+  const newState = { ...currentState, showChatWhenTyping: { isEnabled } };
   setCustomizableState(newState);
   return newState;
 };

--- a/src/types/context.type.ts
+++ b/src/types/context.type.ts
@@ -39,6 +39,7 @@ export type IContextType = {
   toggleAppIconVisibility: (isVisible: boolean) => Promise<void>;
   toggleAlwaysOnTop: (isEnabled: boolean) => Promise<void>;
   toggleTitlesVisibility: (isEnabled: boolean) => void;
+  toggleShowChatWhenTyping: (isEnabled: boolean) => void;
   loadData: () => void;
   pluelyApiEnabled: boolean;
   setPluelyApiEnabled: (enabled: boolean) => void;


### PR DESCRIPTION
Introduces a new customizable setting to display chat history while typing. Adds toggle UI component, updates context and storage logic, and integrates the feature into the input and settings components.
It is a setting the user can turn on or off

