### PR TITLE
Make the Card component draggable and add necessary Tauri permissions

### DIFF
--- a/src-tauri/capabilities/cross-platform.json
+++ b/src-tauri/capabilities/cross-platform.json
@@ -6,6 +6,7 @@
   "platforms": ["windows", "linux"],
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
     "opener:default",
     "updater:default",
     "keychain:default",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "platforms": ["macOS"],
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
     "opener:default",
     "updater:default",
     "macos-permissions:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,12 +39,7 @@ fn set_window_height(window: tauri::WebviewWindow, height: u32) -> Result<(), St
     let new_size = LogicalSize::new(700.0, height as f64);
     
     match window.set_size(Size::Logical(new_size)) {
-        Ok(_) => {
-            if let Err(e) = window::position_window_top_center(&window, 54) {
-                eprintln!("Failed to reposition window: {}", e);
-            }
-            Ok(())
-        }
+        Ok(_) => Ok(()),
         Err(e) => Err(format!("Failed to resize window: {}", e))
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Card, Settings, SystemAudio, Updater } from "./components";
 import { Completion } from "./components/completion";
 import { ChatHistory } from "./components/history";
@@ -7,12 +7,48 @@ import { StatusIndicator } from "./components/speech/StatusIndicator";
 import { useTitles } from "./hooks";
 import { useSystemAudio } from "./hooks/useSystemAudio";
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+const INTERACTIVE_SELECTOR = [
+  "button",
+  "a[href]",
+  "input",
+  "textarea",
+  "select",
+  "label",
+  "summary",
+  "[role='button']",
+  "[role='tab']",
+  "[role='option']",
+  "[contenteditable='true']",
+  "[data-no-drag]",
+  "[data-tauri-drag-disabled]",
+].join(", ");
+
+const isInteractiveElement = (element: EventTarget | null) => {
+  if (!(element instanceof HTMLElement)) return false;
+  return Boolean(element.closest(INTERACTIVE_SELECTOR));
+};
 
 const App = () => {
   const systemAudio = useSystemAudio();
   const [isHidden, setIsHidden] = useState(false);
   // Initialize title management
   useTitles();
+  const handleCardPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const isMouseEvent = event.pointerType === "mouse" || event.pointerType === "";
+    if (isMouseEvent && event.button !== 0) return;
+    if (isInteractiveElement(event.target)) return;
+    if (typeof window === "undefined") return;
+
+    event.preventDefault();
+
+    getCurrentWindow()
+      .startDragging()
+      .catch((error) => {
+        console.error("Failed to start dragging window:", error);
+      });
+  }, []);
   const handleSelectConversation = (conversation: any) => {
     // Use localStorage to communicate the selected conversation to Completion component
     localStorage.setItem("selectedConversation", JSON.stringify(conversation));
@@ -69,7 +105,10 @@ const App = () => {
         isHidden ? "hidden pointer-events-none" : ""
       }`}
     >
-      <Card className="w-full flex flex-row items-center gap-2 p-2">
+      <Card
+        className="w-full flex flex-row items-center gap-2 p-2"
+        onPointerDown={handleCardPointerDown}
+      >
         <SystemAudio {...systemAudio} />
         {systemAudio?.capturing ? (
           <div className="flex flex-row items-center gap-2 justify-between w-full">


### PR DESCRIPTION
this PR 
* hooks the card background into Tauri’s drag API while skipping interactive controls and preventing default pointer behavior so the window follows the mouse/trackpad without breaking button clicks
* grants the core:window:allow-start-dragging capability for every platform bundle so startDragging() can execute without permission errors
* stops the resize command from re-centering the window, preserving whatever location the user dragged it to