### PR TITLE
Added stable scrolling behaviour when using audio-helper module

### DIFF
--- a/src/components/speech/OperationSection.tsx
+++ b/src/components/speech/OperationSection.tsx
@@ -1,13 +1,13 @@
 import { ChatConversation } from "@/types";
 import { Markdown } from "../Markdown";
-import { Button, Card } from "../ui";
+import { Button, Card, Label, Switch } from "../ui";
 import {
   BotIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   HeadphonesIcon,
 } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { QuickActions } from "./QuickActions";
 
 type Props = {
@@ -26,6 +26,8 @@ type Props = {
   handleQuickActionClick: (action: string) => void;
 };
 
+const SCROLL_THRESHOLD_PX = 32;
+
 export const OperationSection = ({
   lastTranscription,
   lastAIResponse,
@@ -42,6 +44,118 @@ export const OperationSection = ({
   handleQuickActionClick,
 }: Props) => {
   const [openConversation, setOpenConversation] = useState(true);
+  const [isAutoScrollEnabled, setIsAutoScrollEnabled] = useState(true);
+  const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
+  const [pendingNewMessages, setPendingNewMessages] = useState(0);
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
+  const visibleMessages = useMemo(() => {
+    return conversation.messages
+      .slice(2)
+      .sort((a, b) => a.timestamp - b.timestamp);
+  }, [conversation.messages]);
+
+  const previousVisibleCountRef = useRef(visibleMessages.length);
+
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = "smooth") => {
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      container.scrollTo({
+        top: container.scrollHeight,
+        behavior,
+      });
+    },
+    []
+  );
+
+  const checkIfPinnedToBottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return true;
+
+    const distanceToBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+    return distanceToBottom <= SCROLL_THRESHOLD_PX;
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    const isAtBottom = checkIfPinnedToBottom();
+    setIsPinnedToBottom((previous) =>
+      previous === isAtBottom ? previous : isAtBottom
+    );
+
+    if (isAtBottom) {
+      setPendingNewMessages(0);
+    }
+  }, [checkIfPinnedToBottom]);
+
+  useEffect(() => {
+    const hasNewMessages =
+      visibleMessages.length > previousVisibleCountRef.current;
+
+    if (isAutoScrollEnabled && isPinnedToBottom) {
+      const behavior: ScrollBehavior = hasNewMessages ? "smooth" : "auto";
+      scrollToBottom(behavior);
+      setPendingNewMessages(0);
+      requestAnimationFrame(() => {
+        const isAtBottom = checkIfPinnedToBottom();
+        setIsPinnedToBottom((previous) =>
+          previous === isAtBottom ? previous : isAtBottom
+        );
+      });
+    } else {
+      if (hasNewMessages) {
+        const newCount =
+          visibleMessages.length - previousVisibleCountRef.current;
+        if (newCount > 0) {
+          setPendingNewMessages((previous) => previous + newCount);
+        }
+      }
+
+      requestAnimationFrame(() => {
+        const isAtBottom = checkIfPinnedToBottom();
+        setIsPinnedToBottom((previous) =>
+          previous === isAtBottom ? previous : isAtBottom
+        );
+        if (isAtBottom) {
+          setPendingNewMessages(0);
+        }
+      });
+    }
+
+    previousVisibleCountRef.current = visibleMessages.length;
+  }, [
+    visibleMessages,
+    isAutoScrollEnabled,
+    isPinnedToBottom,
+    scrollToBottom,
+    checkIfPinnedToBottom,
+  ]);
+
+  const handleAutoScrollToggle = useCallback(
+    (checked: boolean) => {
+      setIsAutoScrollEnabled(checked);
+      if (checked) {
+        setIsPinnedToBottom(true);
+        setPendingNewMessages(0);
+        requestAnimationFrame(() => {
+          scrollToBottom("auto");
+        });
+      }
+    },
+    [scrollToBottom]
+  );
+
+  const handleJumpToLatest = useCallback(() => {
+    scrollToBottom();
+    setIsPinnedToBottom(true);
+    setPendingNewMessages(0);
+  }, [scrollToBottom]);
+
+  const shouldShowJumpToLatest =
+    pendingNewMessages > 0 && !isPinnedToBottom;
+
   return (
     <div className="space-y-4">
       {/* AI Response */}
@@ -83,7 +197,7 @@ export const OperationSection = ({
         </>
       )}
 
-      {conversation.messages.length > 2 && (
+      {visibleMessages.length > 0 && (
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <h3
@@ -93,6 +207,19 @@ export const OperationSection = ({
               Conversations
             </h3>
             <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2">
+                <Label
+                  htmlFor="auto-scroll-toggle"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Auto-scroll
+                </Label>
+                <Switch
+                  id="auto-scroll-toggle"
+                  checked={isAutoScrollEnabled}
+                  onCheckedChange={handleAutoScrollToggle}
+                />
+              </div>
               <Button
                 variant="outline"
                 size="icon"
@@ -118,28 +245,49 @@ export const OperationSection = ({
 
           {openConversation ? (
             <>
-              {conversation.messages.length > 2 &&
-                conversation?.messages
-                  ?.slice(2)
-                  .sort((a, b) => b.timestamp - a.timestamp)
-                  .map((message) => (
-                    <div className="space-y-3 flex flex-row gap-2">
-                      <div className="flex items-start gap-2">
-                        <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center">
-                          {message.role === "user" ? (
-                            <HeadphonesIcon className="h-4 w-4 text-muted-foreground" />
-                          ) : (
-                            <BotIcon className="h-4 w-4 text-muted-foreground" />
-                          )}
+              {visibleMessages.length > 0 && (
+                <div className="relative">
+                  <div
+                    ref={scrollContainerRef}
+                    onScroll={handleScroll}
+                    className="max-h-80 overflow-y-auto pr-1 space-y-3 pb-10"
+                  >
+                    {visibleMessages.map((message) => (
+                      <div
+                        key={message.id}
+                        className="space-y-3 flex flex-row gap-2"
+                      >
+                        <div className="flex items-start gap-2">
+                          <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center">
+                            {message.role === "user" ? (
+                              <HeadphonesIcon className="h-4 w-4 text-muted-foreground" />
+                            ) : (
+                              <BotIcon className="h-4 w-4 text-muted-foreground" />
+                            )}
+                          </div>
                         </div>
+                        <Card className="p-3 bg-transparent">
+                          <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                            <Markdown>{message.content}</Markdown>
+                          </p>
+                        </Card>
                       </div>
-                      <Card className="p-3 bg-transparent">
-                        <p className="text-sm leading-relaxed whitespace-pre-wrap">
-                          <Markdown>{message.content}</Markdown>
-                        </p>
-                      </Card>
+                    ))}
+                  </div>
+                  {shouldShowJumpToLatest && (
+                    <div className="pointer-events-none absolute inset-x-0 bottom-3 flex justify-center">
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={handleJumpToLatest}
+                        className="pointer-events-auto"
+                      >
+                        Jump to latest ({pendingNewMessages})
+                      </Button>
                     </div>
-                  ))}
+                  )}
+                </div>
+              )}
             </>
           ) : null}
         </div>


### PR DESCRIPTION
This PR:
* Implements stable scroll behaviour for the speech operation conversation so users can read older messages while new ones arrive
* Adds an auto-scroll toggle with a fallback "Jump to latest" control to quickly return to the newest message batch