### PR TITLE
fix: resolve Tauri event listener race condition and memory leak in screenshot hooks

### DIFF
--- a/src/hooks/useChatCompletion.ts
+++ b/src/hooks/useChatCompletion.ts
@@ -619,10 +619,11 @@ export const useChatCompletion = (
   }, [handleScreenshotSubmit, hasActiveLicense]);
 
   useEffect(() => {
-    let unlisten: any;
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
 
     const setupListener = async () => {
-      unlisten = await listen("captured-selection", async (event: any) => {
+      const fn = await listen("captured-selection", async (event: any) => {
         // Only process if this context initiated the screenshot
         if (!screenshotInitiatedByThisContext.current) {
           return;
@@ -654,11 +655,18 @@ export const useChatCompletion = (
           }, 100);
         }
       });
+      // If cleanup already ran before the listener resolved, unregister immediately
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
     };
 
     setupListener();
 
     return () => {
+      cancelled = true;
       if (unlisten) {
         unlisten();
       }
@@ -666,14 +674,20 @@ export const useChatCompletion = (
   }, [handleScreenshotSubmit]);
 
   useEffect(() => {
-    const unlisten = listen("capture-closed", () => {
+    let unlisten: (() => void) | undefined;
+
+    listen("capture-closed", () => {
       setIsScreenshotLoading(false);
       isProcessingScreenshotRef.current = false;
       screenshotInitiatedByThisContext.current = false;
+    }).then((fn) => {
+      unlisten = fn;
     });
 
     return () => {
-      unlisten.then((fn) => fn());
+      if (unlisten) {
+        unlisten();
+      }
     };
   }, []);
 

--- a/src/hooks/useCompletion.ts
+++ b/src/hooks/useCompletion.ts
@@ -917,10 +917,11 @@ export const useCompletion = () => {
   }, [handleScreenshotSubmit]);
 
   useEffect(() => {
-    let unlisten: any;
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
 
     const setupListener = async () => {
-      unlisten = await listen("captured-selection", async (event: any) => {
+      const fn = await listen("captured-selection", async (event: any) => {
         if (!screenshotInitiatedByThisContext.current) {
           return;
         }
@@ -951,11 +952,18 @@ export const useCompletion = () => {
           }, 100);
         }
       });
+      // If cleanup already ran before the listener resolved, unregister immediately
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
     };
 
     setupListener();
 
     return () => {
+      cancelled = true;
       if (unlisten) {
         unlisten();
       }
@@ -963,14 +971,20 @@ export const useCompletion = () => {
   }, [handleScreenshotSubmit]);
 
   useEffect(() => {
-    const unlisten = listen("capture-closed", () => {
+    let unlisten: (() => void) | undefined;
+
+    listen("capture-closed", () => {
       setIsScreenshotLoading(false);
       isProcessingScreenshotRef.current = false;
       screenshotInitiatedByThisContext.current = false;
+    }).then((fn) => {
+      unlisten = fn;
     });
 
     return () => {
-      unlisten.then((fn) => fn());
+      if (unlisten) {
+        unlisten();
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Bug

Two `useEffect` hooks in `useChatCompletion.ts` and `useCompletion.ts` have a race condition that causes Tauri event listeners to leak when the component unmounts.

**Problem 1 — `captured-selection` listener:**
`setupListener()` is an async function called fire-and-forget. `listen()` is awaited inside it, but React's cleanup function can run *before* that `await` resolves. When that happens, `unlisten` is still `undefined` at cleanup time — the listener is never unregistered, keeps firing on the dead component, and leaks memory.

```ts
// Before — unlisten may be undefined when cleanup runs
let unlisten: any;
const setupListener = async () => {
  unlisten = await listen("captured-selection", ...); // cleanup may fire here
};
setupListener(); // not awaited
return () => {
  if (unlisten) unlisten(); // silently skipped if setup hasn't resolved yet
};
```

**Problem 2 — `capture-closed` listener:**
`unlisten` is assigned the raw `Promise<() => void>` instead of the resolved function. The cleanup calls `unlisten.then((fn) => fn())`, which is unreliable — if the Promise hasn't resolved yet, the `.then()` callback runs after the component is already gone.

## Fix

- Added a `cancelled` flag in the `captured-selection` effect. After `listen()` resolves, if `cancelled` is already `true`, the unsubscribe function is called immediately instead of being stored — preventing any leak regardless of timing.
- Tightened `unlisten` type from `any` to `(() => void) | undefined` to make this class of bug visible at compile time.
- Restructured the `capture-closed` effect to store the resolved function via `.then()` assignment and call it with a null-guard in cleanup — same pattern, no more raw Promise in cleanup.

Both hooks (`useChatCompletion.ts` and `useCompletion.ts`) had identical copies of the bug and are fixed identically.

## Affected files
- `src/hooks/useChatCompletion.ts`
- `src/hooks/useCompletion.ts`