### PR TITLE
fix: remove unsupported reasoning_effort from Groq provider config

### DIFF
--- a/src/config/ai-providers.constants.ts
+++ b/src/config/ai-providers.constants.ts
@@ -88,7 +88,6 @@ export const AI_PROVIDERS = [
       "max_completion_tokens": 8192,
       "top_p": 1,
       "stream": true,
-      "reasoning_effort": "medium",
       "stop": null
     }'`,
     responseContentPath: "choices[0].message.content",


### PR DESCRIPTION
## Description
The Groq provider's default cURL template included `"reasoning_effort": "medium"`, which is only supported by a subset of Groq models (e.g., GPT-OSS series). Most models like Qwen 3 only accept `none` or `default`, and many others do not support the parameter at all.

This caused a API request failed: 400 - `{"error":{"message":"\`reasoning_effort\` must be one of \`none\` or \`default\`","type":"invalid_request_error"}}` for many users.

## Changes
- Removed `reasoning_effort` from the default template. This fixes the issue for all Groq models out of the box. Users who specifically need it for supported models can still add it via custom provider configuration.