### PR TITLE
Fix panel stealing focus from other apps on macOS Tahoe

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -253,5 +253,9 @@ fn init(app_handle: &AppHandle) {
             | NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces,
     );
 
+    // Prevent the panel from auto-hiding when the app deactivates,
+    // since it must remain visible when other apps are focused.
+    panel.set_hides_on_deactivate(false);
+
     panel.set_delegate(delegate);
 }

--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -11,6 +11,17 @@ use tokio::time::{sleep, Duration};
 use tauri_nspanel::ManagerExt;
 
 use crate::window::show_dashboard_window;
+
+/// Shows the main panel and makes it key window WITHOUT activating the app.
+/// This prevents focus-stealing from other applications on macOS Tahoe+.
+#[cfg(target_os = "macos")]
+fn show_panel_without_activation<R: Runtime>(app: &AppHandle<R>) {
+    if let Ok(panel) = app.get_webview_panel("main") {
+        panel.make_first_responder(Some(panel.content_view()));
+        panel.order_front_regardless();
+        panel.make_key_window();
+    }
+}
 // State for window visibility
 pub struct WindowVisibility {
     #[allow(dead_code)]
@@ -235,15 +246,18 @@ fn handle_toggle_window<R: Runtime>(app: &AppHandle<R>) {
                 eprintln!("Failed to show window: {}", e);
             }
 
-            if let Err(e) = window.set_focus() {
-                eprintln!("Failed to focus window: {}", e);
-            }
-
             #[cfg(target_os = "macos")]
             {
-                let panel = app.get_webview_panel("main").unwrap();
-                panel.show();
+                // Use panel APIs to show without activating the app (stealing focus)
+                show_panel_without_activation(app);
             }
+            #[cfg(not(target_os = "macos"))]
+            {
+                if let Err(e) = window.set_focus() {
+                    eprintln!("Failed to focus window: {}", e);
+                }
+            }
+
             // Emit event to focus text input
             window.emit("focus-text-input", json!({})).unwrap();
         }
@@ -261,6 +275,9 @@ fn handle_audio_shortcut<R: Runtime>(app: &AppHandle<R>) {
             if let Err(_e) = window.show() {
                 return;
             }
+            #[cfg(target_os = "macos")]
+            show_panel_without_activation(app);
+            #[cfg(not(target_os = "macos"))]
             if let Err(e) = window.set_focus() {
                 eprintln!("Failed to focus window: {}", e);
             }
@@ -292,6 +309,9 @@ fn handle_system_audio_shortcut<R: Runtime>(app: &AppHandle<R>) {
                 eprintln!("Failed to show window: {}", e);
                 return;
             }
+            #[cfg(target_os = "macos")]
+            show_panel_without_activation(app);
+            #[cfg(not(target_os = "macos"))]
             if let Err(e) = window.set_focus() {
                 eprintln!("Failed to focus window: {}", e);
             }
@@ -613,6 +633,9 @@ fn handle_focus_input<R: Runtime>(app: &AppHandle<R>) {
             let _ = window.show();
         }
 
+        #[cfg(target_os = "macos")]
+        show_panel_without_activation(app);
+        #[cfg(not(target_os = "macos"))]
         let _ = window.set_focus();
         let _ = window.emit("focus-text-input", json!({}));
     }


### PR DESCRIPTION
## Summary

- On macOS 26.3.1 (Tahoe), the floating panel steals focus from foreground apps (e.g. Chrome) when shown via shortcut. This is because Tauri's `window.set_focus()` calls `[NSApp activateIgnoringOtherApps:YES]`, which now overrides the `NSWindowStyleMaskNonActivatingPanel` behavior on Tahoe.
- Replaced all `window.set_focus()` calls for the main panel window on macOS with direct NSPanel APIs (`order_front_regardless` + `make_key_window` + `make_first_responder`) that show the panel and enable keyboard input without activating the app process.
- Added `set_hides_on_deactivate(false)` to prevent the panel from auto-hiding when another app is focused.

Fixes #230

## Files changed

- `src-tauri/src/shortcuts.rs` — Added `show_panel_without_activation()` helper; replaced `window.set_focus()` in 4 shortcut handlers (`toggle_window`, `audio`, `system_audio`, `focus_input`) with panel-specific APIs on macOS. Windows/Linux behavior unchanged.
- `src-tauri/src/lib.rs` — Added `panel.set_hides_on_deactivate(false)` to panel initialization.

## Test plan

- [x] Open Chrome (or any app) and click into URL bar
- [x] Press Pluely toggle shortcut → panel appears, Chrome stays focused
- [x] Type in panel → text input works
- [x] Hide panel → Chrome still focused
- [x] Test audio, system audio, and focus input shortcuts — same behavior
- [x] Dashboard toggle still correctly steals focus (regular window, not panel)

Tested on macOS 26.3.1 (25D2128).