### PR TITLE
Fix: Prevent window blur/focus detection on Windows (#131)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,6 +60,11 @@ tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wasapi = "0.19.0"
+windows = { version = "0.58", features = [
+  "Win32_UI_WindowsAndMessaging",
+  "Win32_Foundation",
+]}
+   
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libpulse-binding = "2.30.1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -119,6 +119,23 @@ pub fn run() {
         .setup(|app| {
             // Setup main window positioning
             window::setup_main_window(app).expect("Failed to setup main window");
+            #[cfg(target_os = "windows")]
+            {
+                use windows::Win32::UI::WindowsAndMessaging::{
+                    GetWindowLongW, SetWindowLongW,
+                    GWL_EXSTYLE, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
+                };
+                let main_window = app.get_webview_window("main").unwrap();
+                let hwnd = main_window.hwnd().unwrap();
+                unsafe {
+                    let ex_style = GetWindowLongW(hwnd, GWL_EXSTYLE);
+                    SetWindowLongW(
+                        hwnd,
+                        GWL_EXSTYLE,
+                        ex_style | WS_EX_NOACTIVATE.0 as i32 | WS_EX_TOOLWINDOW.0 as i32,
+                    );
+                 }
+            } 
             #[cfg(target_os = "macos")]
             init(app.app_handle());
             let app_handle = app.handle();


### PR DESCRIPTION
Problem
The overlay window fired detectable focus/blur events on Windows,
making it easy for meeting platforms or monitoring tools to detect
Pluely's activity, breaking stealth functionality.

Fix
- Applied `WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW` extended window 
  styles on Windows via raw HWND, preventing the window from ever 
  activating or appearing in alt-tab/taskbar
- Added `windows` crate dependency with required Win32 features

Testing
Tested on Windows — window no longer triggers focus events
when switching between applications.

Closes #131