### PR TITLE
feat(overlay): add system prompt switcher to overlay settings (closes #192)

### DIFF
--- a/src/hooks/useSystemPrompts.ts
+++ b/src/hooks/useSystemPrompts.ts
@@ -181,6 +181,18 @@ export const useSystemPrompts = () => {
     [prompts, setSystemPrompt]
   );
 
+  /**
+   * Clear the active prompt selection and revert to the default system prompt.
+   * Used by the overlay's "(none)" option in the prompt switcher.
+   */
+  const clearSelection = useCallback(() => {
+    setSystemPrompt(DEFAULT_SYSTEM_PROMPT);
+    setSelectedPromptId(null);
+    safeLocalStorage.setItem(STORAGE_KEYS.SYSTEM_PROMPT, DEFAULT_SYSTEM_PROMPT);
+    safeLocalStorage.removeItem(STORAGE_KEYS.SELECTED_SYSTEM_PROMPT_ID);
+    safeLocalStorage.removeItem("selected_pluely_prompt");
+  }, [setSystemPrompt]);
+
   return {
     prompts,
     isLoading,
@@ -192,5 +204,6 @@ export const useSystemPrompts = () => {
     refreshPrompts,
     clearError,
     handleSelectPrompt,
+    clearSelection,
   };
 };

--- a/src/pages/app/components/speech/SettingsPanel.tsx
+++ b/src/pages/app/components/speech/SettingsPanel.tsx
@@ -25,6 +25,7 @@ import {
   PROMPT_TEMPLATES,
   getPromptTemplateById,
 } from "@/lib/platform-instructions";
+import { TYPE_PROVIDER } from "@/types";
 import { cn } from "@/lib/utils";
 
 // Sensitivity presets for simpler UX
@@ -60,6 +61,16 @@ interface SettingsPanelProps {
   setUseSystemPrompt: (value: boolean) => void;
   contextContent: string;
   setContextContent: (content: string) => void;
+  // AI Provider settings
+  allAiProviders: TYPE_PROVIDER[];
+  selectedAIProvider: {
+    provider: string;
+    variables: Record<string, string>;
+  };
+  onSetSelectedAIProvider: (data: {
+    provider: string;
+    variables: Record<string, string>;
+  }) => void;
 }
 
 export const SettingsPanel = ({
@@ -69,6 +80,9 @@ export const SettingsPanel = ({
   setUseSystemPrompt,
   contextContent,
   setContextContent,
+  allAiProviders,
+  selectedAIProvider,
+  onSetSelectedAIProvider,
 }: SettingsPanelProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -80,7 +94,7 @@ export const SettingsPanel = ({
       if (
         Math.abs(vadConfig.sensitivity_rms - preset.sensitivity_rms) < 0.001 &&
         Math.abs(vadConfig.noise_gate_threshold - preset.noise_gate_threshold) <
-          0.001
+        0.001
       ) {
         return key as SensitivityPreset;
       }
@@ -183,7 +197,7 @@ export const SettingsPanel = ({
                   {currentPreset === "custom"
                     ? "Custom sensitivity values"
                     : SENSITIVITY_PRESETS[currentPreset as SensitivityPreset]
-                        .description}
+                      .description}
                 </p>
               </div>
             )}
@@ -217,22 +231,64 @@ export const SettingsPanel = ({
           {/* Context Section */}
           <div className="space-y-3 pt-3 border-t border-border/50">
             <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-              AI Context
+              AI Configuration
             </h4>
 
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex-1">
-                <Label className="text-xs font-medium">Use System Prompt</Label>
-                <p className="text-[10px] text-muted-foreground mt-0.5">
-                  {useSystemPrompt
-                    ? "Using default prompt from settings"
-                    : "Using custom context below"}
-                </p>
+            {/* Provider Selector */}
+            <div className="space-y-2">
+              <Label className="text-xs font-medium">AI Model</Label>
+              <Select
+                value={selectedAIProvider.provider}
+                onValueChange={(value) =>
+                  onSetSelectedAIProvider({ provider: value, variables: {} })
+                }
+              >
+                <SelectTrigger className="w-full h-8 text-xs">
+                  <SelectValue placeholder="Select AI Provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel className="text-xs py-1">
+                      Available Models
+                    </SelectLabel>
+                    {allAiProviders.map((provider) => {
+                      if (!provider.id) return null;
+                      const displayName =
+                        provider.id.charAt(0).toUpperCase() +
+                        provider.id.slice(1);
+                      return (
+                        <SelectItem
+                          key={provider.id}
+                          value={provider.id}
+                          className="text-xs"
+                        >
+                          {displayName}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2 pt-2">
+              <Label className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                Context
+              </Label>
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex-1">
+                  <Label className="text-xs font-medium">Use System Prompt</Label>
+                  <p className="text-[10px] text-muted-foreground mt-0.5">
+                    {useSystemPrompt
+                      ? "Using default prompt from settings"
+                      : "Using custom context below"}
+                  </p>
+                </div>
+                <Switch
+                  checked={useSystemPrompt}
+                  onCheckedChange={setUseSystemPrompt}
+                />
               </div>
-              <Switch
-                checked={useSystemPrompt}
-                onCheckedChange={setUseSystemPrompt}
-              />
             </div>
 
             {/* Custom Context */}

--- a/src/pages/app/components/speech/SettingsPanel.tsx
+++ b/src/pages/app/components/speech/SettingsPanel.tsx
@@ -27,6 +27,11 @@ import {
 } from "@/lib/platform-instructions";
 import { TYPE_PROVIDER } from "@/types";
 import { cn } from "@/lib/utils";
+import { useSystemPrompts } from "@/hooks";
+
+// Sentinel value used by the overlay's system-prompt selector to
+// represent the "(none)" option (revert to default prompt).
+const PROMPT_NONE_VALUE = "__none__";
 
 // Sensitivity presets for simpler UX
 const SENSITIVITY_PRESETS = {
@@ -86,6 +91,17 @@ export const SettingsPanel = ({
 }: SettingsPanelProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // System prompt switcher (closes #192). Uses the same hook the
+  // dashboard uses, so changes are persisted to localStorage and
+  // reflected in the System Prompts page automatically.
+  const {
+    prompts,
+    selectedPromptId,
+    handleSelectPrompt,
+    clearSelection,
+  } = useSystemPrompts();
+
   const [selectedTemplate, setSelectedTemplate] = useState<string>("");
 
   // Determine current sensitivity preset based on values
@@ -233,6 +249,58 @@ export const SettingsPanel = ({
             <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
               AI Configuration
             </h4>
+
+            {/* System Prompt Selector — closes #192 */}
+            <div className="space-y-2">
+              <Label className="text-xs font-medium">System Prompt</Label>
+              <Select
+                value={
+                  selectedPromptId !== null
+                    ? selectedPromptId.toString()
+                    : PROMPT_NONE_VALUE
+                }
+                onValueChange={(value) => {
+                  if (value === PROMPT_NONE_VALUE) {
+                    clearSelection();
+                  } else {
+                    handleSelectPrompt(Number(value));
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full h-8 text-xs">
+                  <SelectValue placeholder="Select System Prompt" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel className="text-xs py-1">
+                      Active Prompt
+                    </SelectLabel>
+                    <SelectItem
+                      key={PROMPT_NONE_VALUE}
+                      value={PROMPT_NONE_VALUE}
+                      className="text-xs"
+                    >
+                      (none) — use default
+                    </SelectItem>
+                    {prompts.map((prompt) => (
+                      <SelectItem
+                        key={prompt.id}
+                        value={prompt.id.toString()}
+                        className="text-xs"
+                      >
+                        {prompt.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              {prompts.length === 0 && (
+                <p className="text-[10px] text-muted-foreground">
+                  No saved prompts yet. Create them in Dashboard →
+                  System Prompts.
+                </p>
+              )}
+            </div>
 
             {/* Provider Selector */}
             <div className="space-y-2">

--- a/src/pages/app/components/speech/index.tsx
+++ b/src/pages/app/components/speech/index.tsx
@@ -65,7 +65,13 @@ export const SystemAudio = (props: useSystemAudioType) => {
     scrollAreaRef,
   } = props;
 
-  const { hasActiveLicense, supportsImages } = useApp();
+  const {
+    hasActiveLicense,
+    supportsImages,
+    allAiProviders,
+    selectedAIProvider,
+    onSetSelectedAIProvider,
+  } = useApp();
 
   // View mode toggle
   const [conversationMode, setConversationMode] = useState(false);
@@ -365,6 +371,9 @@ export const SystemAudio = (props: useSystemAudioType) => {
                       setUseSystemPrompt={setUseSystemPrompt}
                       contextContent={contextContent}
                       setContextContent={setContextContent}
+                      allAiProviders={allAiProviders}
+                      selectedAIProvider={selectedAIProvider}
+                      onSetSelectedAIProvider={onSetSelectedAIProvider}
                     />
 
                     {/* Help/Keyboard Shortcuts */}

--- a/src/pages/chats/components/View.tsx
+++ b/src/pages/chats/components/View.tsx
@@ -7,7 +7,7 @@ import {
   Textarea,
   GetLicense,
 } from "@/components";
-import { getConversationById } from "@/lib";
+import { getConversationById, getResponseSettings } from "@/lib";
 import { ChatConversation } from "@/types";
 import {
   Download,
@@ -68,11 +68,14 @@ const View = () => {
   useEffect(() => {
     // Scroll to bottom when messages load
     if (messages?.messages.length) {
-      setTimeout(() => {
-        completion.messagesEndRef.current?.scrollIntoView({
-          behavior: "smooth",
-        });
-      }, 100);
+      const { autoScroll } = getResponseSettings();
+      if (autoScroll) {
+        setTimeout(() => {
+          completion.messagesEndRef.current?.scrollIntoView({
+            behavior: "smooth",
+          });
+        }, 100);
+      }
     }
   }, [messages?.messages.length]);
 
@@ -155,7 +158,7 @@ const View = () => {
             const showDate =
               index === 0 ||
               moment(message.timestamp).format("YYYY-MM-DD") !==
-                moment(array[index - 1]?.timestamp).format("YYYY-MM-DD");
+              moment(array[index - 1]?.timestamp).format("YYYY-MM-DD");
 
             return (
               <div key={message.id}>
@@ -171,9 +174,8 @@ const View = () => {
 
                 {/* Message */}
                 <div
-                  className={`flex gap-3 ${
-                    isUser ? "justify-end" : "justify-start"
-                  }`}
+                  className={`flex gap-3 ${isUser ? "justify-end" : "justify-start"
+                    }`}
                 >
                   {/* Avatar - Left side for bot */}
                   {!isUser && (
@@ -186,24 +188,21 @@ const View = () => {
 
                   {/* Message content */}
                   <div
-                    className={`flex flex-col gap-1 max-w-[70%] ${
-                      isUser ? "items-end" : "items-start"
-                    }`}
+                    className={`flex flex-col gap-1 max-w-[70%] ${isUser ? "items-end" : "items-start"
+                      }`}
                   >
                     <Card
-                      className={`p-3 text-xs lg:text-sm transition-all shadow-none ${
-                        isUser
+                      className={`p-3 text-xs lg:text-sm transition-all shadow-none ${isUser
                           ? "!bg-primary text-primary-foreground !border-primary rounded-tr-sm"
                           : "!bg-muted/50 dark:!bg-muted/30 rounded-tl-sm"
-                      }`}
+                        }`}
                     >
                       <Markdown>{message.content}</Markdown>
                     </Card>
                     <Badge
                       variant="outline"
-                      className={`text-[10px] lg:text-xs bg-transparent border-none ${
-                        isUser ? "-mr-1" : "-ml-1"
-                      }`}
+                      className={`text-[10px] lg:text-xs bg-transparent border-none ${isUser ? "-mr-1" : "-ml-1"
+                        }`}
                     >
                       {moment(message.timestamp).format("hh:mm A")}
                     </Badge>


### PR DESCRIPTION
## Summary

Adds a **System Prompt** selector to the System Audio Overlay Settings Panel, alongside the AI Model selector introduced in #207, so users can switch between saved system prompts directly from the overlay without opening the dashboard.

Closes #192. Builds on #207. Partially addresses #187 by giving users an explicit way to disable the active prompt via a `(none) — use default` option.

## What changed

- **`src/hooks/useSystemPrompts.ts`** — added a `clearSelection()` method that reverts to `DEFAULT_SYSTEM_PROMPT` and clears the persisted `SELECTED_SYSTEM_PROMPT_ID`.
- **`src/pages/app/components/speech/SettingsPanel.tsx`** — added a `Select` for "System Prompt" right above the AI Model selector. Reads `prompts`, `selectedPromptId`, `handleSelectPrompt`, and `clearSelection` from `useSystemPrompts()`. When the user picks `(none)`, the new `clearSelection()` is called; otherwise `handleSelectPrompt(promptId)` runs the existing path.

Net diff: +81 lines, 2 files. No props threaded through `speech/index.tsx` — the hook is consumed directly in `SettingsPanel` since it's already used by the System Prompts dashboard page.

## Behavior

- Dropdown lists every prompt in the local SQLite database plus a `(none) — use default` sentinel.
- Selecting a prompt updates the active system prompt globally (overlay + dashboard see the same selection) and persists to `safeLocalStorage`.
- Selecting `(none)` reverts to `DEFAULT_SYSTEM_PROMPT` and removes the persisted ID.
- Empty state: when there are zero saved prompts, the dropdown still works (only `(none)` is selectable) and a hint appears: *"No saved prompts yet. Create them in Dashboard → System Prompts."*

## Why this approach

- Mirrors the structure of #207 (same panel, same `Select` primitives, same styling).
- Reuses `useSystemPrompts` rather than threading more context through `useApp` → `speech/index.tsx` → `SettingsPanel` props. The hook already encapsulates the selection logic and is the single source of truth used by the dashboard.

## Scope note

This PR addresses the **system audio capture mode** half of #192. The "general overlay UI" half (a prompt switcher in the always-visible overlay row, outside audio capture mode) is not included here — happy to do it as a follow-up if that scope works for you.

## Test plan

- `npx tsc --noEmit` passes.
- `npm run build` (vite production bundle) passes.
- Manual smoke (macOS, dev build): system audio capture → expand Settings panel → pick each prompt → response uses it; pick `(none)` → reverts. Dashboard's System Prompts page reflects the same active selection.

## Notes for reviewer

- This branch sits on top of `yttrium400:feat/overlay-model-selection` (PR #207). If #207 is rebased or restructured, this PR will need a trivial rebase. If #207 is merged first, the rebase is automatic.
