### PR TITLE
fix(system-prompts): keep Generate-with-AI button clear of dialog close X

### DIFF
--- a/src/pages/system-prompts/CreateEditDialog.tsx
+++ b/src/pages/system-prompts/CreateEditDialog.tsx
@@ -53,7 +53,7 @@ export const CreateEditDialog = ({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[600px] max-h-[85vh] flex flex-col p-0">
         <DialogHeader className="mt-4 px-6 shrink-0">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-4 pr-8">
             <div>
               <DialogTitle>
                 {isEditing ? "Edit System Prompt" : "Create System Prompt"}


### PR DESCRIPTION
## Summary

The "Generate with AI" button in the Create/Edit System Prompt dialog overlapped the dialog's close (×) button on macOS — the close X was rendered partially on top of the right edge of the Generate button (~9px horizontal / 12px vertical overlap).

Root cause: shadcn's `DialogContent` renders the close button absolutely at `top-4 right-4`. The header's flex row used `justify-between` with no right padding, letting `GenerateSystemPrompt` extend flush to the right edge of the header content area, directly under the close X.

## Fix

One-line change in `src/pages/system-prompts/CreateEditDialog.tsx`:

```diff
- <div className="flex items-center justify-between">
+ <div className="flex items-center justify-between gap-4 pr-8">
```

- `pr-8` (32px) clears the close X (16px button + 16px right offset).
- `gap-4` keeps the title block from crowding the Generate button when the dialog is narrow.

## Test plan

- `npx tsc --noEmit` passes.
- `npm run build` passes.
- Manual: open Dashboard → System Prompts → Edit any prompt. The close X is now clearly separated from the Generate with AI button.
