### PR TITLE
Fix Windows overlay focus detection

### DIFF
--- a/src-tauri/src/shortcuts.rs
+++ b/src-tauri/src/shortcuts.rs
@@ -11,6 +11,38 @@ use tokio::time::{sleep, Duration};
 use tauri_nspanel::ManagerExt;
 
 use crate::window::show_dashboard_window;
+#[cfg(target_os = "windows")]
+use crate::window::{ensure_main_window_non_focusable, show_main_window_without_focus};
+
+#[inline]
+fn should_focus_overlay_window() -> bool {
+    !cfg!(target_os = "windows")
+}
+
+fn show_overlay_window_for_shortcut<R: Runtime>(
+    window: &tauri::WebviewWindow<R>,
+) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        show_main_window_without_focus(window)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        window
+            .show()
+            .map_err(|e| format!("Failed to show window: {}", e))?;
+
+        if should_focus_overlay_window() {
+            window
+                .set_focus()
+                .map_err(|e| format!("Failed to focus window: {}", e))?;
+        }
+
+        Ok(())
+    }
+}
+
 // State for window visibility
 pub struct WindowVisibility {
     #[allow(dead_code)]
@@ -196,19 +228,28 @@ fn handle_toggle_window<R: Runtime>(app: &AppHandle<R>) {
     {
         let state = app.state::<WindowVisibility>();
         let mut is_hidden = state.is_hidden.lock().unwrap();
-        *is_hidden = !*is_hidden;
+        let next_hidden = !*is_hidden;
+
+        let visibility_result = if next_hidden {
+            window
+                .hide()
+                .map_err(|e| format!("Failed to hide window: {}", e))
+        } else {
+            show_main_window_without_focus(&window)
+        };
+
+        if let Err(e) = visibility_result {
+            eprintln!("{}", e);
+            return;
+        }
+
+        *is_hidden = next_hidden;
 
         if let Err(e) = window.emit("toggle-window-visibility", *is_hidden) {
             eprintln!("Failed to emit toggle-window-visibility event: {}", e);
         }
 
         if !*is_hidden {
-            if let Err(e) = window.show() {
-                eprintln!("Failed to show window: {}", e);
-            }
-            if let Err(e) = window.set_focus() {
-                eprintln!("Failed to focus window: {}", e);
-            }
             if let Err(e) = window.emit("focus-text-input", json!({})) {
                 eprintln!("Failed to emit focus-text-input event: {}", e);
             }
@@ -258,11 +299,9 @@ fn handle_audio_shortcut<R: Runtime>(app: &AppHandle<R>) {
     if let Some(window) = app.get_webview_window("main") {
         // Ensure window is visible
         if let Ok(false) = window.is_visible() {
-            if let Err(_e) = window.show() {
+            if let Err(e) = show_overlay_window_for_shortcut(&window) {
+                eprintln!("Failed to show window: {}", e);
                 return;
-            }
-            if let Err(e) = window.set_focus() {
-                eprintln!("Failed to focus window: {}", e);
             }
         }
 
@@ -288,12 +327,9 @@ fn handle_system_audio_shortcut<R: Runtime>(app: &AppHandle<R>) {
     if let Some(window) = app.get_webview_window("main") {
         // Ensure window is visible
         if let Ok(false) = window.is_visible() {
-            if let Err(e) = window.show() {
+            if let Err(e) = show_overlay_window_for_shortcut(&window) {
                 eprintln!("Failed to show window: {}", e);
                 return;
-            }
-            if let Err(e) = window.set_focus() {
-                eprintln!("Failed to focus window: {}", e);
             }
         }
 
@@ -610,11 +646,38 @@ fn handle_focus_input<R: Runtime>(app: &AppHandle<R>) {
     if let Some(window) = app.get_webview_window("main") {
         // Ensure window is visible
         if let Ok(false) = window.is_visible() {
+            #[cfg(target_os = "windows")]
+            let _ = show_main_window_without_focus(&window);
+
+            #[cfg(not(target_os = "windows"))]
             let _ = window.show();
         }
 
-        let _ = window.set_focus();
+        #[cfg(target_os = "windows")]
+        ensure_main_window_non_focusable(&window);
+
+        if should_focus_overlay_window() {
+            let _ = window.set_focus();
+        }
+
         let _ = window.emit("focus-text-input", json!({}));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_focus_overlay_window;
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn overlay_focus_requests_are_disabled_on_windows() {
+        assert!(!should_focus_overlay_window());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn overlay_focus_requests_are_preserved_on_non_windows() {
+        assert!(should_focus_overlay_window());
     }
 }
 

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -19,11 +19,31 @@ pub fn setup_main_window(app: &mut App) -> Result<(), Box<dyn std::error::Error>
 
     position_window_top_center(&window, TOP_OFFSET)?;
 
-    // Set window as non-focusable on Windows
-    // #[cfg(target_os = "windows")]
-    // {
-    //     let _ = window.set_focusable(false);
-    // }
+    ensure_main_window_non_focusable(&window);
+
+    Ok(())
+}
+
+/// Keeps the overlay from becoming the active OS window on platforms that support it.
+#[cfg(target_os = "windows")]
+pub fn ensure_main_window_non_focusable<R: Runtime>(window: &WebviewWindow<R>) {
+    if let Err(e) = window.set_focusable(false) {
+        eprintln!("Failed to set main window non-focusable: {}", e);
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn ensure_main_window_non_focusable<R: Runtime>(_window: &WebviewWindow<R>) {}
+
+/// Shows the main overlay without requesting OS focus.
+pub fn show_main_window_without_focus<R: Runtime>(
+    window: &WebviewWindow<R>,
+) -> Result<(), String> {
+    ensure_main_window_non_focusable(window);
+    window
+        .show()
+        .map_err(|e| format!("Failed to show window: {}", e))?;
+    ensure_main_window_non_focusable(window);
 
     Ok(())
 }

--- a/src/hooks/useApp.ts
+++ b/src/hooks/useApp.ts
@@ -79,16 +79,18 @@ export const useApp = () => {
       (event) => {
         const platform = navigator.platform.toLowerCase();
         if (typeof event.payload === "boolean" && platform.includes("win")) {
-          setIsHidden(!event.payload);
-          // find popover open and close it
+          setIsHidden(event.payload);
+          // Close any open popover when the overlay visibility changes.
           const popover = document.getElementById("popover-content");
-          // set display to none, change data-state to closed
           if (popover) {
-            popover.style.setProperty("display", "none", "important");
-            // update the data-state to closed
+            if (event.payload) {
+              popover.style.setProperty("display", "none", "important");
+            } else {
+              popover.style.removeProperty("display");
+            }
+
             popover.setAttribute("data-state", "closed");
 
-            // Also find and update the popover trigger's data-state
             const popoverTriggers = document.querySelectorAll(
               '[data-slot="popover-trigger"]'
             );


### PR DESCRIPTION
## Summary
- keep the Windows main overlay non-focusable so showing/toggling it does not steal OS focus
- route Windows shortcut show paths through a no-focus overlay helper while preserving existing macOS/Linux focus behavior
- fix the Windows visibility event payload handling so the frontend hidden state matches the backend state

Fixes #131

## Why
The Windows overlay path was showing the main window and then explicitly focusing it. That can blur the user's active application and make Pluely visible to focus/window-event detection. The fix uses Tauri's focusable window support for the main overlay on Windows and avoids focus requests from shortcut paths that reveal the overlay.

## Validation
- npm run build
- git diff --check

Note: cargo/rustfmt were not available on this local machine, so Rust compile/format checks still need to run in CI or on a machine with the Rust toolchain installed.