### PR TITLE
Add OpenRouter as STT and text provider

### DIFF
--- a/src/config/stt.constants.ts
+++ b/src/config/stt.constants.ts
@@ -102,4 +102,20 @@ export const SPEECH_TO_TEXT_PROVIDERS = [
     responseContentPath: "results[0].alternatives[0].transcript",
     streaming: false,
   },
+  {
+    id: "openrouter-stt",
+    name: "OpenRouter Speech-to-Text",
+    curl: `curl -X POST "https://openrouter.ai/api/v1/audio/transcriptions" \\
+      -H "Authorization: Bearer {{API_KEY}}" \\
+      -H "Content-Type: application/json" \\
+      -d '{
+        "model": "{{MODEL}}",
+        "input_audio": {
+          "data": "{{AUDIO}}",
+          "format": "wav"
+        }
+      }'`,
+    responseContentPath: "text",
+    streaming: false,
+  },
 ];

--- a/src/lib/functions/stt.function.ts
+++ b/src/lib/functions/stt.function.ts
@@ -1,5 +1,6 @@
 import {
   deepVariableReplacer,
+  extractVariables,
   getByPath,
   blobToBase64,
 } from "./common.function";
@@ -83,6 +84,18 @@ export async function fetchSTT(params: STTParams): Promise<string> {
     // if (file.size > maxSize) {
     //   warnings.push("Audio exceeds 10MB limit");
     // }
+
+    // Validate required variables are configured
+    const requiredVars = extractVariables(provider.curl).filter(
+      ({ key }) => key !== "audio"
+    );
+    for (const { key } of requiredVars) {
+      if (!selectedProvider.variables?.[key]?.trim()) {
+        throw new Error(
+          `Missing required variable: ${key}. Please configure it in settings.`
+        );
+      }
+    }
 
     // Build variable map
     const allVariables = {


### PR DESCRIPTION
## Summary

- Add `openrouter-stt` to `SPEECH_TO_TEXT_PROVIDERS` using OpenRouter's JSON-body STT API (`input_audio.data` base64 format) — distinct from the multipart form format used by OpenAI/Groq
- OpenRouter text provider (`openrouter`) was already present in `AI_PROVIDERS`
- Fix missing required-variable validation in `fetchSTT`: previously, leaving a variable like `MODEL` blank would silently send the literal `{{MODEL}}` string to the API; now surfaces a clear error matching the guard already in `fetchAIResponse`

## Test plan

- [ ] Go to Settings → STT Providers, select `openrouter-stt`
- [ ] Fill in `api_key` and `model` (e.g. `nvidia/parakeet-tdt-0.6b-v3`), confirm transcription works via mic button
- [ ] Leave `model` blank, confirm error message reads "Missing required variable: model. Please configure it in settings." instead of a raw HTTP error
- [ ] Select `openrouter` as AI provider, fill in `api_key` and `model` (e.g. `minimax/minimax-m3`), confirm chat completions work
- [ ] Verify no regressions on other STT providers (openai-whisper, groq, elevenlabs)