### PR TITLE
Add local LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ Hit Start and Pluely transcribes your mic and system audio live, with speaker la
 
 The full tour with visuals is at **[pluely.com/features](https://pluely.com/features)**, and pricing is at **[pluely.com/pricing](https://pluely.com/pricing)**.
 
+## 🖥️ Run it fully local with Ollama (or any other local LLM)
+
+Pluely doesn't require a hosted provider at all — point it at a local model and everything stays on your machine.
+
+1. Install [Ollama](https://ollama.com/) and pull a model, e.g. `ollama pull llama3`.
+2. Make sure Ollama is running (`ollama serve`, or it's already running in the background).
+3. In Pluely's provider settings, add Ollama using its built-in curl template, which targets `http://localhost:11434/v1/chat/completions`. No API key is needed — Ollama's local endpoint doesn't require an `Authorization` header.
+4. Set the model field to match what you pulled (e.g. `llama3`).
+
+Any other local or self-hosted server with an OpenAI-compatible `/v1/chat/completions` endpoint (LM Studio, vLLM, llama.cpp server, text-generation-webui, etc.) works the same way: add it as a custom provider with a curl template pointed at its local URL, and drop the `Authorization` header if the server doesn't require one.
+
 ## 📚 Documentation
 
 [docs.pluely.com](https://docs.pluely.com) covers every feature, setting, and edge case, with per-OS guides where platforms differ:

--- a/src/components/Markdown/speak-button.tsx
+++ b/src/components/Markdown/speak-button.tsx
@@ -1,0 +1,40 @@
+import { Volume2, Square } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useTextToSpeech } from "@/hooks";
+import { Button } from "@/components/ui/button";
+
+type SpeakButtonProps = {
+  content: string;
+};
+
+export function SpeakButton({ content }: SpeakButtonProps) {
+  const { isSupported, isSpeaking, speak } = useTextToSpeech();
+
+  if (!isSupported) return null;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="relative h-6 w-6"
+      aria-label={isSpeaking ? "Stop reading aloud" : "Read aloud"}
+      title={isSpeaking ? "Stop reading aloud" : "Read aloud"}
+      onClick={() => speak(content)}
+    >
+      <div className="absolute inset-0 flex items-center justify-center">
+        <Square
+          className={cn(
+            "h-3.5 w-3.5 transition-transform ease-in-out fill-current",
+            isSpeaking ? "scale-100" : "scale-0"
+          )}
+        />
+      </div>
+      <Volume2
+        className={cn(
+          "h-4 w-4 transition-transform ease-in-out",
+          isSpeaking ? "scale-0" : "scale-100"
+        )}
+      />
+    </Button>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,4 +10,5 @@ export * from "./CustomCursor";
 export * from "./Sidebar";
 export * from "./Empty";
 export * from "./Markdown/copy-button";
+export * from "./Markdown/speak-button";
 export * from "./Icons";

--- a/src/config/ai-providers.constants.ts
+++ b/src/config/ai-providers.constants.ts
@@ -1,3 +1,4 @@
+
 export const AI_PROVIDERS = [
   {
     id: "openai",
@@ -121,7 +122,6 @@ export const AI_PROVIDERS = [
   {
     id: "ollama",
     curl: `curl -X POST http://localhost:11434/v1/chat/completions \\
-    -H "Authorization: Bearer {{API_KEY}}" \\
     -H "Content-Type: application/json" \\
     -d '{
     "model": "{{MODEL}}",

--- a/src/config/stt.constants.ts
+++ b/src/config/stt.constants.ts
@@ -1,5 +1,14 @@
 export const SPEECH_TO_TEXT_PROVIDERS = [
   {
+    id: "local-whisper",
+    name: "Local Whisper (Offline, Free, No API Key)",
+    curl: `curl -X POST "http://127.0.0.1:8080/inference" \\
+      -F "file={{AUDIO}}" \\
+      -F "response_format=json"`,
+    responseContentPath: "text",
+    streaming: false,
+  },
+  {
     id: "openai-whisper",
     name: "OpenAI Whisper",
     curl: `curl -X POST "https://api.openai.com/v1/audio/transcriptions" \\

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,6 +10,7 @@ export * from "./useShortcuts";
 export * from "./useSystemAudio";
 export * from "./useHistory";
 export * from "./useCopyToClipboard";
+export * from "./useTextToSpeech";
 export * from "./useTitles";
 export * from "./useSystemPrompts";
 export * from "./useApp";

--- a/src/hooks/useTextToSpeech.ts
+++ b/src/hooks/useTextToSpeech.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from "react";
+
+// Strip markdown syntax so the speech engine doesn't read out symbols like
+// "asterisk asterisk" or "backtick" for **bold** / `code` / etc.
+const stripMarkdown = (text: string) =>
+  text
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/[*_#>~-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+export function useTextToSpeech() {
+  const isSupported =
+    typeof window !== "undefined" && "speechSynthesis" in window;
+  const [isSpeaking, setIsSpeaking] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (isSupported) window.speechSynthesis.cancel();
+    };
+  }, [isSupported]);
+
+  const stop = useCallback(() => {
+    if (!isSupported) return;
+    window.speechSynthesis.cancel();
+    setIsSpeaking(false);
+  }, [isSupported]);
+
+  const speak = useCallback(
+    (text: string) => {
+      if (!isSupported || !text.trim()) return;
+
+      // Clicking again while speaking should stop it
+      if (isSpeaking) {
+        stop();
+        return;
+      }
+
+      window.speechSynthesis.cancel();
+
+      const utterance = new SpeechSynthesisUtterance(stripMarkdown(text));
+      utterance.onstart = () => setIsSpeaking(true);
+      utterance.onend = () => setIsSpeaking(false);
+      utterance.onerror = () => setIsSpeaking(false);
+
+      window.speechSynthesis.speak(utterance);
+    },
+    [isSupported, isSpeaking, stop]
+  );
+
+  return { isSupported, isSpeaking, speak, stop };
+}

--- a/src/pages/app/components/completion/Audio.tsx
+++ b/src/pages/app/components/completion/Audio.tsx
@@ -9,7 +9,6 @@ export const Audio = ({
   setMicOpen,
   enableVAD,
   setEnableVAD,
-  submit,
   setState,
 }: UseCompletionReturn) => {
   const { selectedSttProvider, pluelyApiEnabled, selectedAudioDevices } =
@@ -23,7 +22,6 @@ export const Audio = ({
         {(pluelyApiEnabled || speechProviderStatus) && enableVAD ? (
           <AutoSpeechVAD
             key={selectedAudioDevices.input.id}
-            submit={submit}
             setState={setState}
             setEnableVAD={setEnableVAD}
             microphoneDeviceId={selectedAudioDevices.input.id}

--- a/src/pages/app/components/completion/AutoSpeechVad.tsx
+++ b/src/pages/app/components/completion/AutoSpeechVad.tsx
@@ -9,14 +9,12 @@ import { floatArrayToWav } from "@/lib/utils";
 import { shouldUsePluelyAPI } from "@/lib/functions/pluely.api";
 
 interface AutoSpeechVADProps {
-  submit: UseCompletionReturn["submit"];
   setState: UseCompletionReturn["setState"];
   setEnableVAD: UseCompletionReturn["setEnableVAD"];
   microphoneDeviceId?: string;
 }
 
 const AutoSpeechVADInternal = ({
-  submit,
   setState,
   setEnableVAD,
   microphoneDeviceId,
@@ -76,7 +74,12 @@ const AutoSpeechVADInternal = ({
         });
 
         if (transcription) {
-          submit(transcription);
+          setState((prev: any) => ({
+            ...prev,
+            input: prev.input
+              ? `${prev.input} ${transcription}`.trim()
+              : transcription,
+          }));
         }
       } catch (error) {
         console.error("Failed to transcribe audio:", error);

--- a/src/pages/app/components/speech/ResultsSection.tsx
+++ b/src/pages/app/components/speech/ResultsSection.tsx
@@ -1,5 +1,5 @@
 import { ChatConversation } from "@/types";
-import { Markdown, Switch, CopyButton } from "@/components";
+import { Markdown, Switch, CopyButton, SpeakButton } from "@/components";
 import { BotIcon, HeadphonesIcon, Loader2, SparklesIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -49,7 +49,12 @@ export const ResultsSection = ({
             onCheckedChange={setConversationMode}
             className="scale-75"
           />
-          {lastAIResponse && <CopyButton content={lastAIResponse} />}
+          {lastAIResponse && (
+            <>
+              <SpeakButton content={lastAIResponse} />
+              <CopyButton content={lastAIResponse} />
+            </>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
Summary

Adds a local Whisper STT provider (local-whisper) so voice input can be transcribed fully offline via a local whisper.cpp-style server (http://127.0.0.1:8080/inference), with no API key required.
Fixes the Ollama provider's example curl command, which sent an Authorization: Bearer header even though local Ollama doesn't require one.
Adds a text-to-speech "read aloud" button (SpeakButton + useTextToSpeech hook) next to AI responses, using the browser's built-in speechSynthesis API — no external TTS service needed, keeping the local/offline-first workflow consistent end to end.
Auto Speech VAD now appends transcribed text into the input field instead of auto-submitting, so users can review/edit before sending.
Motivation

Pluely currently assumes a cloud AI/STT provider is configured. These changes make it usable fully offline with a local LLM (via Ollama) and local speech-to-text (via a local Whisper server), with local TTS for responses — no API keys, no network calls.

Testing

Manually tested local Ollama chat completions.
Manually tested local Whisper transcription endpoint.
Manually tested the read-aloud button in-browser.